### PR TITLE
Bugfix for OSError: [Errno 24] Too many open files

### DIFF
--- a/sdk/request_utils/rest_client.py
+++ b/sdk/request_utils/rest_client.py
@@ -122,9 +122,10 @@ class RestClient(object):
 
     def stop(self):
         """
-        Stop rest client immediately.
+        Stop rest client immediately and close pools.
         """
         self._active = False
+        self._pool.close()
 
     def join(self):
         """


### PR DESCRIPTION
Close multiprocessing.Pool when closing RestClient. When opening RestClient multiple times you get error: "OSError: [Errno 24] Too many open files", which is caused because Pool's are not closing automatically. This commit fixes that.